### PR TITLE
Add center-crop scaling preprocess option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ python train.py --dataroot ./datasets/cityscapes --name city_SB \
 --mode sb --lambda_SB 1.0 --lambda_NCE 1.0 --gpu_ids 0 --direction B2A
 ```
 
+To resize inputs to a specific resolution while preserving the original aspect ratio, use the new preprocessing mode:
+
+```
+--preprocess scale_width_and_height --img_width 512 --img_height 384
+```
+
+The image is scaled so that it fills the requested width and height and then center-cropped to the exact target size. When not specified, both `--img_width` and `--img_height` default to `256`.
+
 for summer2winter,
 
 ```

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -60,8 +60,12 @@ class BaseOptions():
         parser.add_argument('--batch_size', type=int, default=1, help='input batch size')
         parser.add_argument('--load_size', type=int, default=286, help='scale images to this size')
         parser.add_argument('--crop_size', type=int, default=256, help='then crop to this size')
+        parser.add_argument('--img_width', type=int, default=256,
+                            help='target width used when preprocess is scale_width_and_height')
+        parser.add_argument('--img_height', type=int, default=256,
+                            help='target height used when preprocess is scale_width_and_height')
         parser.add_argument('--max_dataset_size', type=int, default=float("inf"), help='Maximum number of samples allowed per dataset. If the dataset directory contains more than max_dataset_size, only a subset is loaded.')
-        parser.add_argument('--preprocess', type=str, default='resize_and_crop', help='scaling and cropping of images at load time [resize_and_crop | crop | scale_width | scale_width_and_crop | none]')
+        parser.add_argument('--preprocess', type=str, default='resize_and_crop', help='scaling and cropping of images at load time [resize_and_crop | crop | scale_width | scale_width_and_crop | scale_width_and_height | none]')
         parser.add_argument('--no_flip', action='store_true', help='if specified, do not flip the images for data augmentation')
         parser.add_argument('--display_winsize', type=int, default=256, help='display window size for both visdom and HTML')
         parser.add_argument('--random_scale_max', type=float, default=3.0,


### PR DESCRIPTION
## Summary
- add a scale_width_and_height preprocessing path that scales images to fill a target resolution while maintaining the aspect ratio and center-crops the result
- expose img_width and img_height command-line options (default 256) for configuring the new preprocessing target size

## Testing
- python -m compileall data options *(fails: existing SyntaxError in options/ncsn_options.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c9407df4c8832298a1942f09a4d131