### PR TITLE
Disable argparse abbreviations for options

### DIFF
--- a/options/base_options.py
+++ b/options/base_options.py
@@ -90,7 +90,10 @@ class BaseOptions():
         in model and dataset classes.
         """
         if not self.initialized:  # check if it has been initialized
-            parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+            parser = argparse.ArgumentParser(
+                formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+                allow_abbrev=False,
+            )
             parser = self.initialize(parser)
 
         # get the basic options


### PR DESCRIPTION
## Summary
- construct the root argument parser with `allow_abbrev=False` to prevent `argparse` from misreading flags such as `--mode`

## Testing
- python train.py --help *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68c778b724388322bda5b4537ddd0082