### PR TITLE
Support optional mask-guided data loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ bash ./datasets/download_cut_dataset.sh horse2zebra
 Due to copyright issue, we do not directly provide cityscapes dataset. 
 please refer to the original repository of [CUT](https://github.com/taesungp/contrastive-unpaired-translation).
 
-## Training 
+## Training
 Refer the ```./run_train.sh``` file or
 
 ```
@@ -66,7 +66,13 @@ python train.py --dataroot ./datasets/horse2zebra --name h2z_SB \
 --mode sb --lambda_SB 1.0 --lambda_NCE 1.0 --gpu_ids 0
 ```
 
-for cityscapes and map2sat, 
+To enable foreground/background-aware translation, prepare matching mask folders next to the RGB data. For each of the original
+`trainA`, `trainB`, `testA`, and `testB` directories, add a counterpart with the `_mask` suffix (for example, `trainA_mask`).
+Every mask folder should contain grayscale images that share the exact filenames with their RGB partners. When launching
+training or evaluation, add `--use_mask` to consume the mask folders automatically and feed a 4-channel (RGB+mask) tensor into
+the mask-guided generator.
+
+for cityscapes and map2sat,
 
 ```
 python train.py --dataroot ./datasets/cityscapes --name city_SB \

--- a/README.md
+++ b/README.md
@@ -68,9 +68,16 @@ python train.py --dataroot ./datasets/horse2zebra --name h2z_SB \
 
 To enable foreground/background-aware translation, prepare matching mask folders next to the RGB data. For each of the original
 `trainA`, `trainB`, `testA`, and `testB` directories, add a counterpart with the `_mask` suffix (for example, `trainA_mask`).
-Every mask folder should contain grayscale images that share the exact filenames with their RGB partners. When launching
-training or evaluation, add `--use_mask` to consume the mask folders automatically and feed a 4-channel (RGB+mask) tensor into
-the mask-guided generator.
+Every mask folder should contain grayscale images that share the exact filenames with their RGB partners. Masks should be
+binary with black (`0`) background and white (`255`) foreground; after normalization they are interpreted as 0 for background and
+1 for foreground.
+
+When launching training or evaluation, add `--use_mask` to consume the mask folders automatically. Unless you override
+`--netG`, the option switches the generator to `--netG mask_dual`, our mask-guided dual-branch translator. You can control the
+underlying branch architecture via `--mask_dual_branch` (defaults to `resnet_9blocks_cond`). If you prefer experimenting with a
+single-branch 4-channel generator instead, specify another `--netG` explicitly (and set `--input_nc 4` if required by the chosen
+architecture). Regardless of the generator, discriminators continue to operate on RGB only so that they judge full-image
+consistency across mask boundaries.
 
 for cityscapes and map2sat,
 

--- a/data/unaligned_dataset.py
+++ b/data/unaligned_dataset.py
@@ -1,5 +1,6 @@
 import os.path
-from data.base_dataset import BaseDataset, get_transform
+import torch
+from data.base_dataset import BaseDataset, get_params, get_transform
 from data.image_folder import make_dataset
 from PIL import Image
 import random
@@ -26,14 +27,31 @@ class UnalignedDataset(BaseDataset):
         BaseDataset.__init__(self, opt)
         self.dir_A = os.path.join(opt.dataroot, opt.phase + 'A')  # create a path '/path/to/data/trainA'
         self.dir_B = os.path.join(opt.dataroot, opt.phase + 'B')  # create a path '/path/to/data/trainB'
+        self.use_mask = getattr(opt, 'use_mask', False)
+        if self.use_mask:
+            self.dir_A_mask = os.path.join(opt.dataroot, opt.phase + 'A_mask')
+            self.dir_B_mask = os.path.join(opt.dataroot, opt.phase + 'B_mask')
 
         if opt.phase == "test" and not os.path.exists(self.dir_A) \
            and os.path.exists(os.path.join(opt.dataroot, "valA")):
             self.dir_A = os.path.join(opt.dataroot, "valA")
             self.dir_B = os.path.join(opt.dataroot, "valB")
+            if self.use_mask:
+                self.dir_A_mask = os.path.join(opt.dataroot, "valA_mask")
+                self.dir_B_mask = os.path.join(opt.dataroot, "valB_mask")
 
         self.A_paths = sorted(make_dataset(self.dir_A, opt.max_dataset_size))   # load images from '/path/to/data/trainA'
         self.B_paths = sorted(make_dataset(self.dir_B, opt.max_dataset_size))    # load images from '/path/to/data/trainB'
+        if self.use_mask:
+            self.A_mask_paths = sorted(make_dataset(self.dir_A_mask, opt.max_dataset_size))
+            self.B_mask_paths = sorted(make_dataset(self.dir_B_mask, opt.max_dataset_size))
+            if len(self.A_mask_paths) != len(self.A_paths):
+                raise ValueError(f"Mask directory {self.dir_A_mask} must contain the same number of files as {self.dir_A}.")
+            if len(self.B_mask_paths) != len(self.B_paths):
+                raise ValueError(f"Mask directory {self.dir_B_mask} must contain the same number of files as {self.dir_B}.")
+        else:
+            self.A_mask_paths = []
+            self.B_mask_paths = []
         self.A_size = len(self.A_paths)  # get the size of dataset A
         self.B_size = len(self.B_paths)  # get the size of dataset B
 
@@ -57,17 +75,36 @@ class UnalignedDataset(BaseDataset):
         B_path = self.B_paths[index_B]
         A_img = Image.open(A_path).convert('RGB')
         B_img = Image.open(B_path).convert('RGB')
+        if self.use_mask:
+            A_mask_path = self.A_mask_paths[index % self.A_size]
+            B_mask_path = self.B_mask_paths[index_B]
+            A_mask_img = Image.open(A_mask_path).convert('L')
+            B_mask_img = Image.open(B_mask_path).convert('L')
 
         # Apply image transformation
         # For CUT/FastCUT mode, if in finetuning phase (learning rate is decaying),
         # do not perform resize-crop data augmentation of CycleGAN.
         is_finetuning = self.opt.isTrain and self.current_epoch > self.opt.n_epochs
         modified_opt = util.copyconf(self.opt, load_size=self.opt.crop_size if is_finetuning else self.opt.load_size)
-        transform = get_transform(modified_opt)
-        A = transform(A_img)
-        B = transform(B_img)
+        params_A = get_params(modified_opt, A_img.size)
+        params_B = get_params(modified_opt, B_img.size)
+        A_transform = get_transform(modified_opt, params_A)
+        B_transform = get_transform(modified_opt, params_B)
+        A = A_transform(A_img)
+        B = B_transform(B_img)
+        sample = {'A': A, 'B': B, 'A_paths': A_path, 'B_paths': B_path}
 
-        return {'A': A, 'B': B, 'A_paths': A_path, 'B_paths': B_path}
+        if self.use_mask:
+            A_mask_transform = get_transform(modified_opt, params_A, grayscale=True, method=Image.NEAREST)
+            B_mask_transform = get_transform(modified_opt, params_B, grayscale=True, method=Image.NEAREST)
+            A_mask = A_mask_transform(A_mask_img)
+            B_mask = B_mask_transform(B_mask_img)
+            sample['A'] = torch.cat([sample['A'], A_mask], dim=0)
+            sample['B'] = torch.cat([sample['B'], B_mask], dim=0)
+            sample['A_mask'] = A_mask
+            sample['B_mask'] = B_mask
+
+        return sample
 
     def __len__(self):
         """Return the total number of images in the dataset.

--- a/models/networks.py
+++ b/models/networks.py
@@ -247,10 +247,11 @@ def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, in
     net = None
     norm_layer = get_norm_layer(norm_type=norm)
 
-    if opt is not None and getattr(opt, 'use_mask', False):
-        net = MaskGuidedGenerator(input_nc, output_nc, ngf, netG, norm_layer=norm_layer, use_dropout=use_dropout,
+    if netG == 'mask_dual':
+        branch_name = getattr(opt, 'mask_dual_branch', 'resnet_9blocks_cond') if opt is not None else 'resnet_9blocks'
+        net = MaskGuidedGenerator(input_nc, output_nc, ngf, branch_name, norm_layer=norm_layer, use_dropout=use_dropout,
                                   no_antialias=no_antialias, no_antialias_up=no_antialias_up, opt=opt, config=config)
-        initialize_weights = ('stylegan2' not in netG)
+        initialize_weights = ('stylegan2' not in branch_name)
     else:
         if netG == 'resnet_9blocks':
             net = ResnetGenerator(input_nc, output_nc, ngf, norm_layer=norm_layer, use_dropout=use_dropout, no_antialias=no_antialias, no_antialias_up=no_antialias_up, n_blocks=9, opt=opt)
@@ -351,59 +352,59 @@ def define_D(input_nc, ndf, netD, n_layers_D=3, norm='batch', init_type='normal'
 ##############################################################################
 
 
-def _build_generator_branch(netG, input_nc, output_nc, ngf, norm_layer, use_dropout, no_antialias,
+def _build_generator_branch(branch_name, input_nc, output_nc, ngf, norm_layer, use_dropout, no_antialias,
                             no_antialias_up, opt=None, config=None):
     """Utility to instantiate a generator branch mirroring :func:`define_G`."""
-    if netG == 'resnet_9blocks':
+    if branch_name == 'resnet_9blocks':
         return ResnetGenerator(input_nc, output_nc, ngf, norm_layer=norm_layer, use_dropout=use_dropout,
                                no_antialias=no_antialias, no_antialias_up=no_antialias_up, n_blocks=9, opt=opt)
-    if netG == 'resnet_6blocks':
+    if branch_name == 'resnet_6blocks':
         return ResnetGenerator(input_nc, output_nc, ngf, norm_layer=norm_layer, use_dropout=use_dropout,
                                no_antialias=no_antialias, no_antialias_up=no_antialias_up, n_blocks=6, opt=opt)
-    if netG == 'resnet_4blocks':
+    if branch_name == 'resnet_4blocks':
         return ResnetGenerator(input_nc, output_nc, ngf, norm_layer=norm_layer, use_dropout=use_dropout,
                                no_antialias=no_antialias, no_antialias_up=no_antialias_up, n_blocks=4, opt=opt)
-    if netG == 'unet_128':
+    if branch_name == 'unet_128':
         return UnetGenerator(input_nc, output_nc, 7, ngf, norm_layer=norm_layer, use_dropout=use_dropout)
-    if netG == 'unet_256':
+    if branch_name == 'unet_256':
         return UnetGenerator(input_nc, output_nc, 8, ngf, norm_layer=norm_layer, use_dropout=use_dropout)
-    if netG == 'stylegan2':
+    if branch_name == 'stylegan2':
         return StyleGAN2Generator(input_nc, output_nc, ngf, use_dropout=use_dropout, opt=opt)
-    if netG == 'smallstylegan2':
+    if branch_name == 'smallstylegan2':
         return StyleGAN2Generator(input_nc, output_nc, ngf, use_dropout=use_dropout, n_blocks=2, opt=opt)
-    if netG == 'resnet_cat':
+    if branch_name == 'resnet_cat':
         n_blocks = 8
         return G_Resnet(input_nc, output_nc, opt.nz, num_downs=2, n_res=n_blocks - 4, ngf=ngf, norm='inst', nl_layer='relu')
-    if netG == 'ncsnpp':
+    if branch_name == 'ncsnpp':
         return NCSNpp(config)
-    if netG == 'resnet_9blocks_cond':
+    if branch_name == 'resnet_9blocks_cond':
         return ResnetGenerator_ncsn(input_nc, output_nc, ngf, norm_layer=norm_layer, use_dropout=use_dropout,
                                     no_antialias=no_antialias, no_antialias_up=no_antialias_up, n_blocks=9, opt=opt)
-    raise NotImplementedError('Generator branch model name [%s] is not recognized' % netG)
+    raise NotImplementedError('Generator branch model name [%s] is not recognized' % branch_name)
 
 
 class MaskGuidedGenerator(nn.Module):
     """Generator that separates foreground/background streams using a mask channel."""
 
-    def __init__(self, base_input_nc, output_nc, ngf, netG, norm_layer, use_dropout, no_antialias,
+    def __init__(self, base_input_nc, output_nc, ngf, branch_name, norm_layer, use_dropout, no_antialias,
                  no_antialias_up, opt=None, config=None):
         super().__init__()
         self.base_input_nc = base_input_nc
         self.mask_channels = 1
         branch_input_nc = base_input_nc + self.mask_channels
 
-        self.foreground_branch = _build_generator_branch(netG, branch_input_nc, output_nc, ngf, norm_layer,
+        self.foreground_branch = _build_generator_branch(branch_name, branch_input_nc, output_nc, ngf, norm_layer,
                                                          use_dropout, no_antialias, no_antialias_up, opt=opt,
                                                          config=config)
 
         # Background branch is encouraged to hallucinate textures, so enable dropout even when
         # the main generator runs deterministically.
         background_dropout = use_dropout if use_dropout else True
-        self.background_branch = _build_generator_branch(netG, branch_input_nc, output_nc, ngf, norm_layer,
+        self.background_branch = _build_generator_branch(branch_name, branch_input_nc, output_nc, ngf, norm_layer,
                                                          background_dropout, no_antialias, no_antialias_up, opt=opt,
                                                          config=config)
 
-    def forward(self, input):
+    def forward(self, input, *args, **kwargs):
         if input.size(1) >= self.base_input_nc + self.mask_channels:
             image = input[:, :self.base_input_nc]
             mask = input[:, self.base_input_nc:self.base_input_nc + self.mask_channels]
@@ -411,19 +412,57 @@ class MaskGuidedGenerator(nn.Module):
             image = input[:, :self.base_input_nc]
             mask = torch.ones_like(image[:, :1])
 
-        mask = mask.clamp(0.0, 1.0)
+        mask = mask.mul(0.5).add_(0.5).clamp_(0.0, 1.0)
+        mask = mask.type_as(image)
         fg = image * mask
         bg = image * (1.0 - mask)
 
         fg_condition = torch.cat([fg, mask], dim=1)
         bg_condition = torch.cat([bg, 1.0 - mask], dim=1)
 
-        fg_translated = self.foreground_branch(fg_condition)
-        fg_translated = torch.tanh(fg_translated + fg)
+        fg_out, fg_feats = self._run_branch(self.foreground_branch, fg_condition, args, kwargs)
+        bg_out, bg_feats = self._run_branch(self.background_branch, bg_condition, args, kwargs)
 
-        bg_translated = self.background_branch(bg_condition)
+        if (fg_feats is None) != (bg_feats is None):
+            raise RuntimeError('MaskGuidedGenerator expects foreground and background branches to return matching feature sets.')
 
-        return fg_translated * mask + bg_translated * (1.0 - mask)
+        if fg_out is None and bg_out is None:
+            mask_pyramid = self._build_mask_pyramid(mask, fg_feats)
+            return [f_feat * m + b_feat * (1.0 - m)
+                    for f_feat, b_feat, m in zip(fg_feats, bg_feats, mask_pyramid)]
+
+        fg_translated = torch.tanh(fg_out + fg)
+        bg_translated = bg_out
+
+        blended = fg_translated * mask + bg_translated * (1.0 - mask)
+
+        if fg_feats is None and bg_feats is None:
+            return blended
+
+        mask_pyramid = self._build_mask_pyramid(mask, fg_feats)
+        blended_feats = [f_feat * m + b_feat * (1.0 - m)
+                         for f_feat, b_feat, m in zip(fg_feats, bg_feats, mask_pyramid)]
+        return blended, blended_feats
+
+    def _run_branch(self, branch, conditioned_input, args, kwargs):
+        out = branch(conditioned_input, *args, **kwargs)
+        if isinstance(out, tuple):
+            return out
+        if isinstance(out, list):
+            return None, out
+        return out, None
+
+    def _build_mask_pyramid(self, mask, feature_list):
+        if feature_list is None:
+            return None
+        pyramids = []
+        for feat in feature_list:
+            if mask.shape[2:] == feat.shape[2:]:
+                resized = mask
+            else:
+                resized = F.interpolate(mask, size=feat.shape[2:], mode='bilinear', align_corners=False)
+            pyramids.append(resized)
+        return pyramids
 
 
 class GANLoss(nn.Module):

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 from util import util
 import torch
 import models
@@ -38,7 +39,10 @@ class BaseOptions():
         parser.add_argument('--embedding_dim', type=int, default=512, help='# of output image channels: 3 for RGB and 1 for grayscale')
         parser.add_argument('--netD', type=str, default='basic_cond', choices=['basic', 'n_layers', 'pixel', 'patch', 'tilestylegan2', 'stylegan2'], help='specify discriminator architecture. The basic model is a 70x70 PatchGAN. n_layers allows you to specify the layers in the discriminator')
         parser.add_argument('--netE', type=str, default='basic_cond', choices=['basic', 'n_layers', 'pixel', 'patch', 'tilestylegan2', 'stylegan2', 'patchstylegan2'], help='specify discriminator architecture. The basic model is a 70x70 PatchGAN. n_layers allows you to specify the layers in the discriminator')
-        parser.add_argument('--netG', type=str, default='resnet_9blocks_cond', choices=['resnet_9blocks', 'resnet_6blocks', 'unet_256', 'unet_128', 'stylegan2', 'smallstylegan2', 'resnet_cat'], help='specify generator architecture')
+        parser.add_argument('--netG', type=str, default='resnet_9blocks_cond',
+                            choices=['resnet_9blocks', 'resnet_9blocks_cond', 'resnet_6blocks', 'unet_256', 'unet_128',
+                                     'stylegan2', 'smallstylegan2', 'resnet_cat', 'mask_dual'],
+                            help='specify generator architecture')
         parser.add_argument('--embedding_type', type=str, default='positional', choices=['fourier', 'positional'], help='specify generator architecture')
         parser.add_argument('--n_layers_D', type=int, default=3, help='only used if netD==n_layers')
         parser.add_argument('--style_dim', type=int, default=512, help='only used if netD==n_layers')
@@ -46,6 +50,10 @@ class BaseOptions():
         parser.add_argument('--use_mask', action='store_true',
                             help='if specified, load paired foreground/background masks and use a dual-branch generator that ' \
                                  'preserves masked structure while re-synthesising background textures')
+        parser.add_argument('--mask_dual_branch', type=str, default='resnet_9blocks_cond',
+                            choices=['resnet_9blocks', 'resnet_9blocks_cond', 'resnet_6blocks', 'resnet_4blocks',
+                                     'unet_256', 'unet_128', 'stylegan2', 'smallstylegan2', 'resnet_cat', 'ncsnpp'],
+                            help='backbone architecture used inside the mask_dual generator')
         parser.add_argument('--normG', type=str, default='instance', choices=['instance', 'batch', 'none'], help='instance normalization or batch normalization for G')
         parser.add_argument('--normD', type=str, default='instance', choices=['instance', 'batch', 'none'], help='instance normalization or batch normalization for D')
         parser.add_argument('--init_type', type=str, default='xavier', choices=['normal', 'xavier', 'kaiming', 'orthogonal'], help='network initialization')
@@ -118,10 +126,24 @@ class BaseOptions():
 
         # save and return the parser
         self.parser = parser
+        if opt.use_mask and not self._has_argument('--netG'):
+            parser.set_defaults(netG='mask_dual')
+            opt.netG = 'mask_dual'
         if self.cmd_line is None:
             return parser.parse_args()
         else:
             return parser.parse_args(self.cmd_line)
+
+    def _has_argument(self, flag):
+        """Return True if the original command line explicitly provided `flag`."""
+        args = self.cmd_line if self.cmd_line is not None else sys.argv[1:]
+        iterator = iter(args)
+        for token in iterator:
+            if token == flag:
+                return True
+            if token.startswith(flag + '='):
+                return True
+        return False
 
     def print_options(self, opt):
         """Print and save options

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -43,6 +43,9 @@ class BaseOptions():
         parser.add_argument('--n_layers_D', type=int, default=3, help='only used if netD==n_layers')
         parser.add_argument('--style_dim', type=int, default=512, help='only used if netD==n_layers')
         parser.add_argument('--n_mlp', type=int, default=3, help='only used if netD==n_layers')
+        parser.add_argument('--use_mask', action='store_true',
+                            help='if specified, load paired foreground/background masks and use a dual-branch generator that ' \
+                                 'preserves masked structure while re-synthesising background textures')
         parser.add_argument('--normG', type=str, default='instance', choices=['instance', 'batch', 'none'], help='instance normalization or batch normalization for G')
         parser.add_argument('--normD', type=str, default='instance', choices=['instance', 'batch', 'none'], help='instance normalization or batch normalization for D')
         parser.add_argument('--init_type', type=str, default='xavier', choices=['normal', 'xavier', 'kaiming', 'orthogonal'], help='network initialization')

--- a/options/ncsn_options.py
+++ b/options/ncsn_options.py
@@ -73,5 +73,5 @@ def NCSNOptions():
     parser.add_argument('--std', type=float, default=0.25, help='Scale of Gaussian noise added to data')
 
     args, unknown = parser.parse_known_args()
-    args.ch_mult = [1, 2 ,4]
-return args
+    args.ch_mult = [1, 2, 4]
+    return args


### PR DESCRIPTION
## Summary
- rename the mask-aware option to `--use_mask` and keep the dual-branch generator behind it
- teach the unaligned dataset loader to read paired RGB/mask folders and emit 4-channel tensors when the flag is enabled
- document the expected mask directory layout and CLI flag in the README

## Testing
- python -m compileall data models options *(fails: pre-existing syntax error in options/ncsn_options.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ae2245ac83229bfceaddc85d5c9b